### PR TITLE
Highlight the word "unofficial" for FDroid/… builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@ SHA256: 8E:09:CB:8F:9F:28:DA:DB:A9:32:84:AD:7C:AC:F3:E7 \
         can use our <a href=
         "https://download.lineage.microg.org/extra">migration
         ZIP</a>, that replaces the LineageOS' keys with ours.
-        However, if you have installed unofficial builds of:</p>
+        However, if you have installed <b>unofficial</b> builds of:</p>
         <ul>
           <li>F-Droid or F-Droid Privileged Extension</li>
           <li>microG's apps (GmsCore, GsfProxy, FakeStore and


### PR DESCRIPTION
…so users know that they actually do not need to uninstall these apps, if they've installed the official builds.