### PR TITLE
Added "wipe system" to dirty install

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@ SHA256: 8E:09:CB:8F:9F:28:DA:DB:A9:32:84:AD:7C:AC:F3:E7 \
         for microG</a> (make sure the ZIP you're installing is
         newer than the current installed ROM, if it is not, wait
         for the next build), reboot in recovery, install the
-        migration ZIP and, without rebooting, install LineageOS for
+        migration ZIP and, without rebooting, wipe system and install LineageOS for
         microG.</p>
       </section>
       <section>


### PR DESCRIPTION
In my case, upgrading from LOS 14.1 to 15.1 (dirty install) without wiping system prevented apk from being installed (dialog mode and root mode on Yalp Store, and also with build-in file explorer). After wiping system and flashing 15.1 again it was no problem.