### PR TITLE
Change donation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
           "button special icon fa-download">Download</a>
         </li>
         <li>
-          <a href="https://www.bountysource.com/teams/microg" class=
+          <a href="https://liberapay.com/microG/" class=
           "button icon scrolly">
             <i class="fa fa-heart" aria-hidden="true" style="color:#EB1E63;padding-right:0.3em"></i>
             Donate</a>


### PR DESCRIPTION
the website still links to bountysource, which asks users to not donate via boutysource but liberapay or github.